### PR TITLE
Add interface for SchematicValueVisitor

### DIFF
--- a/src/main/java/org/manifold/compiler/ArrayTypeValue.java
+++ b/src/main/java/org/manifold/compiler/ArrayTypeValue.java
@@ -5,14 +5,16 @@ public class ArrayTypeValue extends TypeValue {
   
   private final TypeValue elementType;
   
-  public TypeValue getElementType(){
+  public TypeValue getElementType() {
     return this.elementType;
   }
   
-  public ArrayTypeValue(TypeValue elementType){
+  public ArrayTypeValue(TypeValue elementType) {
     this.elementType = elementType;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/ArrayValue.java
+++ b/src/main/java/org/manifold/compiler/ArrayValue.java
@@ -61,6 +61,8 @@ public class ArrayValue extends Value {
     return true;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
 
 }

--- a/src/main/java/org/manifold/compiler/BooleanTypeValue.java
+++ b/src/main/java/org/manifold/compiler/BooleanTypeValue.java
@@ -10,6 +10,8 @@ public class BooleanTypeValue extends TypeValue {
 
   private BooleanTypeValue() { }
 
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/BooleanValue.java
+++ b/src/main/java/org/manifold/compiler/BooleanValue.java
@@ -37,6 +37,8 @@ public class BooleanValue extends Value {
     return true;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/ConnectionType.java
+++ b/src/main/java/org/manifold/compiler/ConnectionType.java
@@ -16,6 +16,8 @@ public class ConnectionType extends TypeValue {
     return attributes;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/ConnectionValue.java
+++ b/src/main/java/org/manifold/compiler/ConnectionValue.java
@@ -49,6 +49,8 @@ public class ConnectionValue extends Value {
     return true;
   }
 
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/ConstraintType.java
+++ b/src/main/java/org/manifold/compiler/ConstraintType.java
@@ -16,6 +16,8 @@ public class ConstraintType extends TypeValue {
     return attributes;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/ConstraintValue.java
+++ b/src/main/java/org/manifold/compiler/ConstraintValue.java
@@ -28,6 +28,8 @@ public class ConstraintValue extends Value {
     return true;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/IntegerTypeValue.java
+++ b/src/main/java/org/manifold/compiler/IntegerTypeValue.java
@@ -11,6 +11,8 @@ public class IntegerTypeValue extends TypeValue {
     return instance;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/IntegerValue.java
+++ b/src/main/java/org/manifold/compiler/IntegerValue.java
@@ -18,6 +18,8 @@ public class IntegerValue extends Value {
     return false;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
 
 }

--- a/src/main/java/org/manifold/compiler/NilTypeValue.java
+++ b/src/main/java/org/manifold/compiler/NilTypeValue.java
@@ -9,6 +9,8 @@ public class NilTypeValue extends TypeValue {
 
   private NilTypeValue() { }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/NodeTypeValue.java
+++ b/src/main/java/org/manifold/compiler/NodeTypeValue.java
@@ -24,6 +24,8 @@ public class NodeTypeValue extends TypeValue {
     return this.ports;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/NodeValue.java
+++ b/src/main/java/org/manifold/compiler/NodeValue.java
@@ -67,6 +67,8 @@ public class NodeValue extends Value {
     return true;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/PortTypeValue.java
+++ b/src/main/java/org/manifold/compiler/PortTypeValue.java
@@ -15,6 +15,8 @@ public class PortTypeValue extends TypeValue {
     return this.attributes;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/PortValue.java
+++ b/src/main/java/org/manifold/compiler/PortValue.java
@@ -37,6 +37,8 @@ public class PortValue extends Value {
     return true;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/SchematicValueVisitor.java
+++ b/src/main/java/org/manifold/compiler/SchematicValueVisitor.java
@@ -1,0 +1,41 @@
+package org.manifold.compiler;
+
+public interface SchematicValueVisitor {
+
+  void visit(ArrayTypeValue arrayTypeValue);
+
+  void visit(TypeTypeValue typeTypeValue);
+
+  void visit(StringValue stringValue);
+
+  void visit(StringTypeValue stringTypeValue);
+
+  void visit(PortValue portValue);
+
+  void visit(PortTypeValue portTypeValue);
+
+  void visit(NodeValue nodeValue);
+
+  void visit(NodeTypeValue nodeTypeValue);
+
+  void visit(NilTypeValue nilTypeValue);
+
+  void visit(IntegerValue integerValue);
+
+  void visit(ConstraintValue constraintValue);
+
+  void visit(IntegerTypeValue integerTypeValue);
+
+  void visit(ConstraintType constraintType);
+
+  void visit(ConnectionValue connectionValue);
+
+  void visit(ConnectionType connectionType);
+
+  void visit(BooleanValue booleanValue);
+
+  void visit(BooleanTypeValue booleanTypeValue);
+
+  void visit(ArrayValue arrayValue);
+
+}

--- a/src/main/java/org/manifold/compiler/StringTypeValue.java
+++ b/src/main/java/org/manifold/compiler/StringTypeValue.java
@@ -10,6 +10,8 @@ public class StringTypeValue extends TypeValue {
     return instance;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/StringValue.java
+++ b/src/main/java/org/manifold/compiler/StringValue.java
@@ -19,6 +19,8 @@ public class StringValue extends Value {
     return false;
   }
 
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/TypeTypeValue.java
+++ b/src/main/java/org/manifold/compiler/TypeTypeValue.java
@@ -16,6 +16,8 @@ public class TypeTypeValue extends TypeValue {
     return this == type;
   }
   
-  
+  public void accept(SchematicValueVisitor visitor) {
+    visitor.visit(this);
+  }
   
 }

--- a/src/main/java/org/manifold/compiler/Value.java
+++ b/src/main/java/org/manifold/compiler/Value.java
@@ -33,4 +33,12 @@ public abstract class Value {
    */
   public abstract boolean isRuntimeKnowable();
   
+  /*
+   * Allows SchematicValueVisitors to process this Value.
+   * Must be overridden in every subclass of Value that can be instantiated,
+   * usually with code of the form "visitor.visit(this);".
+   */
+  
+  public abstract void accept(SchematicValueVisitor visitor);
+  
 }

--- a/src/test/java/org/manifold/compiler/TestTypeValue.java
+++ b/src/test/java/org/manifold/compiler/TestTypeValue.java
@@ -22,6 +22,10 @@ public class TestTypeValue {
 
     @Override
     public void verify() {}
+    
+    // Not tested.
+    public void accept(SchematicValueVisitor visitor) {}
+    
   }
 
   private TypeValue getInstance() {


### PR DESCRIPTION
This is, as far as I can see, the easiest way to un-break the frontend. This will be done by implementing the interface `SchematicValueVisitor` in the frontend and adding in support for "frontend values", i.e. values like "FunctionValue" that exist in the frontend and not in the schematic.

This re-implements functionality that was already in the frontend (and also doesn't really do anything, because it's just infrastructure for a visitor that's going to be brought in from more existing code).
