### PR TITLE
Add ConnectionTypeValue to the schematic serializer

### DIFF
--- a/src/main/java/org/manifold/compiler/middle/BackAnnotationBuilder.java
+++ b/src/main/java/org/manifold/compiler/middle/BackAnnotationBuilder.java
@@ -336,7 +336,8 @@ public class BackAnnotationBuilder {
         if (originalAttrType instanceof NodeTypeValue) {
           // pull the new node from the isomorphism table
           newAttributes.put(attrName, nodeIsomorphisms.get(originalAttrValue));
-        } else if (originalAttrValue instanceof ConnectionValue) { // TODO ...instanceof ConnectionTypeValue?
+        } else if (originalAttrValue instanceof ConnectionValue) {
+          // TODO ...instanceof ConnectionTypeValue?
           // no connection types, so we have to test the value's type
           // pull the new connection from the isomorphism table
           newAttributes.put(attrName, connectionIsomorphisms.get(

--- a/src/main/java/org/manifold/compiler/middle/Schematic.java
+++ b/src/main/java/org/manifold/compiler/middle/Schematic.java
@@ -81,20 +81,20 @@ public class Schematic {
           // this should not actually be possible unless there is something
           // wrong with the compiler itself
           throw new UndefinedBehaviourError(
-              "could not create default type definitions (" + mde.getMessage()
-                  + ")");
+             "could not create default type definitions ("
+              + mde.getMessage() + ")");
         }
       });
 
-      // TODO: Should this be a Primitive type as well?
-      try {
-        addConnectionType("Connection", ConnectionTypeValue.getInstance());
-      } catch (MultipleDefinitionException mde) {
-        // this should never happen
-        throw new UndefinedBehaviourError(
-                "could not create default connection type definitions (" + mde.getMessage()
-                        + ")");
-      }
+    // TODO: Should this be a Primitive type as well?
+    try {
+      addConnectionType("Connection", ConnectionTypeValue.getInstance());
+    } catch (MultipleDefinitionException mde) {
+      // this should never happen
+      throw new UndefinedBehaviourError(
+          "could not create default connection type definitions ("
+          + mde.getMessage() + ")");
+    }
   }
 
   public void addUserDefinedType(UserDefinedTypeValue td)
@@ -168,7 +168,8 @@ public class Schematic {
     }
   }
 
-  public void addConnectionType(String typename, ConnectionTypeValue connectionType)
+  public void addConnectionType(String typename,
+                                ConnectionTypeValue connectionType)
       throws MultipleDefinitionException {
     if (connectionTypes.containsKey(typename)) {
       throw new MultipleDefinitionException("connection-definition", typename);

--- a/src/main/java/org/manifold/compiler/middle/serialization/SchematicDeserializer.java
+++ b/src/main/java/org/manifold/compiler/middle/serialization/SchematicDeserializer.java
@@ -104,7 +104,8 @@ public class SchematicDeserializer implements SerializationConsts {
       }
 
       Value attrValue;
-      if (value.isJsonPrimitive() && compTable.contains(type, value.getAsString())) {
+      if (value.isJsonPrimitive() &&
+          compTable.contains(type, value.getAsString())) {
         attrValue = compTable.get(type, value.getAsString());
       } else {
         attrValue = type.instantiate(value);
@@ -175,7 +176,8 @@ public class SchematicDeserializer implements SerializationConsts {
 
     for (Entry<String, JsonElement> entry : in.entrySet()) {
       TypeValue udt = deserializeTypeValue(sch, entry.getValue());
-      UserDefinedTypeValue newType = new UserDefinedTypeValue(udt, entry.getKey());
+      UserDefinedTypeValue newType =
+          new UserDefinedTypeValue(udt, entry.getKey());
       compTable.put(entry.getKey(), newType);
       sch.addUserDefinedType(newType);
     }

--- a/src/main/java/org/manifold/compiler/middle/serialization/SchematicSerializer.java
+++ b/src/main/java/org/manifold/compiler/middle/serialization/SchematicSerializer.java
@@ -270,7 +270,8 @@ public class SchematicSerializer {
     schJson.add(CONSTRAINT_TYPES, collection);
   }
 
-  public void addConnectionTypes(Map<String, ConnectionTypeValue> connectionTypes) {
+  public void addConnectionTypes(
+          Map<String, ConnectionTypeValue> connectionTypes) {
     JsonObject collection = new JsonObject();
 
     connectionTypes.forEach((key, val) -> rValueMap.put(val, key));

--- a/src/main/java/org/manifold/compiler/middle/serialization/SchematicSerializer.java
+++ b/src/main/java/org/manifold/compiler/middle/serialization/SchematicSerializer.java
@@ -11,6 +11,7 @@ import static org.manifold.compiler.middle.serialization.SerializationConsts.Nod
 import static org.manifold.compiler.middle.serialization.SerializationConsts.NodeTypeConsts.PORT_MAP;
 import static org.manifold.compiler.middle.serialization.SerializationConsts.PrimitiveTypes.PRIMITIVE_TYPES;
 import static org.manifold.compiler.middle.serialization.SerializationConsts.SchematicConsts.CONNECTION_DEFS;
+import static org.manifold.compiler.middle.serialization.SerializationConsts.SchematicConsts.CONNECTION_TYPES;
 import static org.manifold.compiler.middle.serialization.SerializationConsts.SchematicConsts.CONSTRAINT_DEFS;
 import static org.manifold.compiler.middle.serialization.SerializationConsts.SchematicConsts.CONSTRAINT_TYPES;
 import static org.manifold.compiler.middle.serialization.SerializationConsts.SchematicConsts.NODE_DEFS;
@@ -25,6 +26,7 @@ import java.util.Map;
 
 import org.manifold.compiler.ArrayTypeValue;
 import org.manifold.compiler.BooleanTypeValue;
+import org.manifold.compiler.ConnectionTypeValue;
 import org.manifold.compiler.ConnectionValue;
 import org.manifold.compiler.ConstraintType;
 import org.manifold.compiler.ConstraintValue;
@@ -268,6 +270,14 @@ public class SchematicSerializer {
     schJson.add(CONSTRAINT_TYPES, collection);
   }
 
+  public void addConnectionTypes(Map<String, ConnectionTypeValue> connectionTypes) {
+    JsonObject collection = new JsonObject();
+
+    connectionTypes.forEach((key, val) -> rValueMap.put(val, key));
+
+    schJson.add(CONNECTION_TYPES, collection);
+  }
+
   public void addNodes(Map<String, NodeValue> nodes) {
     JsonObject collection = new JsonObject();
 
@@ -327,6 +337,7 @@ public class SchematicSerializer {
   public static JsonObject serialize(Schematic sch) {
     SchematicSerializer serializer = new SchematicSerializer(sch);
     serializer.addUserDefinedTypes(sch.getUserDefinedTypes());
+    serializer.addConnectionTypes(sch.getConnectionTypes());
     serializer.addPortTypes(sch.getPortTypes());
     serializer.addNodeTypes(sch.getNodeTypes());
     serializer.addConstraintTypes(sch.getConstraintTypes());

--- a/src/main/java/org/manifold/compiler/middle/serialization/SerializationConsts.java
+++ b/src/main/java/org/manifold/compiler/middle/serialization/SerializationConsts.java
@@ -30,6 +30,7 @@ public interface SerializationConsts {
     String PORT_TYPES = "portTypes";
     String NODE_TYPES = "nodeTypes";
     String CONSTRAINT_TYPES = "constraintTypes";
+    String CONNECTION_TYPES = "connectionTypes";
 
     String NODE_DEFS = "nodes";
     String CONNECTION_DEFS = "connections";

--- a/src/test/java/org/manifold/compiler/TestBackAnnotationBuilder.java
+++ b/src/test/java/org/manifold/compiler/TestBackAnnotationBuilder.java
@@ -129,7 +129,8 @@ public class TestBackAnnotationBuilder {
         "din_reference", dinNodeType,
         "port_reference", din,
         "conn_reference", ConnectionTypeValue.getInstance()));
-    originalSchematic.addConstraintType(TEST_CONSTRAINT_TYPE_NAME, constraintType);
+    originalSchematic.addConstraintType(TEST_CONSTRAINT_TYPE_NAME,
+        constraintType);
 
     ConstraintValue constraintValue = new ConstraintValue(constraintType,
         ImmutableMap.of(
@@ -243,7 +244,8 @@ public class TestBackAnnotationBuilder {
   @Test
   public void testModifyPortAttribute()
       throws SchematicException {
-    // Modify the "baz" attribute on nIN:in_port_name to be True instead of False.
+    // Modify the "baz" attribute on nIN:in_port_name to be True instead of
+    // False.
 
     PortValue inOriginal = originalSchematic.getNode("nIN").
         getPort(IN_PORT_NAME);
@@ -327,7 +329,8 @@ public class TestBackAnnotationBuilder {
   @Test
   public void testModifyConnectionAttribute()
       throws SchematicException {
-    // Modify the "xyzzy" attribute on connection "wire" to be False instead of True.
+    // Modify the "xyzzy" attribute on connection "wire" to be False instead of
+    // True.
 
     ConnectionValue cOriginal = originalSchematic.getConnection(
         CONNECTION_NAME);
@@ -480,7 +483,8 @@ public class TestBackAnnotationBuilder {
   @Test
   public void testModifyNodeAttribute_ToInferred()
       throws SchematicException {
-    // Modify the "iBaz" attribute on node "nIN" to be <Inferred> instead of True
+    // Modify the "iBaz" attribute on node "nIN" to be <Inferred> instead of
+    // True
 
     NodeValue inOriginal = originalSchematic.getNode("nIN");
     InferredValue vBar = (InferredValue) inOriginal.getAttribute(NODE_ATTR_BAR);

--- a/src/test/java/org/manifold/compiler/TestSchematic.java
+++ b/src/test/java/org/manifold/compiler/TestSchematic.java
@@ -53,6 +53,13 @@ public class TestSchematic {
   }
 
   @Test(expected = UndeclaredIdentifierException.class)
+  public void testGetConnectionType_Undeclared_ThrowsException()
+          throws SchematicException {
+    Schematic sch = new Schematic("test");
+    ConnectionTypeValue tv = sch.getConnectionType("bogus");
+  }
+
+  @Test(expected = UndeclaredIdentifierException.class)
   public void testGetNode_Undeclared_ThrowsException()
       throws SchematicException {
     Schematic sch = new Schematic("test");
@@ -140,6 +147,17 @@ public class TestSchematic {
     ConstraintType cv1 = new ConstraintType(attributes);
     sch.addConstraintType(constraintTypeName, cv1);
     ConstraintType actual = sch.getConstraintType(constraintTypeName);
+    assertEquals(cv1, actual);
+  }
+
+  @Test
+  public void testGetConnectionType() throws SchematicException {
+    Schematic sch = new Schematic("test");
+    // add the first constraint type
+    String connectionTypeName = "TestConstraint";
+    ConnectionTypeValue cv1 = ConnectionTypeValue.getInstance();
+    sch.addConnectionType(connectionTypeName, cv1);
+    ConnectionTypeValue actual = sch.getConnectionType(connectionTypeName);
     assertEquals(cv1, actual);
   }
 
@@ -409,6 +427,23 @@ public class TestSchematic {
     // try to add another constraint type with the same name
     ConstraintType cv2 = new ConstraintType(attributes);
     sch.addConstraintType(constraintTypeName, cv2);
+  }
+
+  @Test(expected = MultipleDefinitionException.class)
+  public void testAddConnectionType_AlreadyDefined_ThrowsException()
+      throws SchematicException {
+    Schematic sch = new Schematic("test");
+    // add the first constraint type
+    String connectionTypeName = "TestConnection";
+    try {
+      ConnectionTypeValue cv1 = ConnectionTypeValue.getInstance();
+      sch.addConnectionType(connectionTypeName, cv1);
+    } catch (MultipleDefinitionException e) {
+      fail("exception thrown too early");
+    }
+    // try to add another constraint type with the same name
+    ConnectionTypeValue cv2 = ConnectionTypeValue.getInstance();
+    sch.addConnectionType(connectionTypeName, cv2);
   }
 
   @Test(expected = MultipleAssignmentException.class)

--- a/src/test/java/org/manifold/compiler/serialization/TestSerialization.java
+++ b/src/test/java/org/manifold/compiler/serialization/TestSerialization.java
@@ -510,7 +510,6 @@ public class TestSerialization {
     URL url = Resources
         .getResource("org/manifold/compiler/serialization/data/"
             + "deserialization-inferred-attributes-test.json");
-
     JsonObject json = new JsonParser().parse(
         Resources.toString(url, Charsets.UTF_8)).getAsJsonObject();
     Schematic sch = new SchematicDeserializer().deserialize(json);


### PR DESCRIPTION
The Schematic serializer fails when a connection type attribute is in a
constraint. Keep track of the connection types in the Schematic and read
into the serializers type tree on serialize.

All manifold-core tests pass, and I was able to serialize the schematics used in the backend.