### PR TITLE
Make inferred types a subtype of their contained type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ targetCompatibility = 1.8
 
 group = "org.manifold"
 // name = "manifold-core"
-version = '0.11.0-SNAPSHOT'
+version = '0.12.0-SNAPSHOT'
 
 jar {
   manifest {

--- a/src/main/java/org/manifold/compiler/Attributes.java
+++ b/src/main/java/org/manifold/compiler/Attributes.java
@@ -71,10 +71,10 @@ public class Attributes {
       Map<String, Value> data) throws TypeMismatchException {
     for (Map.Entry<String, TypeValue> entry : types.entrySet()) {
       String attrName = entry.getKey();
-      TypeValue expectedType = data.get(attrName).getType();
-      TypeValue actualType = entry.getValue();
-      if (!actualType.isSubtypeOf(expectedType)) {
-        throw new TypeMismatchException(expectedType, actualType);
+      TypeValue dataType = data.get(attrName).getType();
+      TypeValue expectedType = UserDefinedTypeValue.getUnaliasedType(entry.getValue());
+      if (!dataType.isSubtypeOf(expectedType)) {
+        throw new TypeMismatchException(expectedType, dataType);
       }
     }
   }

--- a/src/main/java/org/manifold/compiler/InferredTypeValue.java
+++ b/src/main/java/org/manifold/compiler/InferredTypeValue.java
@@ -28,7 +28,7 @@ public class InferredTypeValue extends TypeValue {
   @Override
   public boolean isSubtypeOf(TypeValue other) {
     if (!(other instanceof InferredTypeValue)) {
-      return false;
+      return this.getInferredType().isSubtypeOf(other);
     }
     InferredTypeValue otherType = (InferredTypeValue) other;
     return (this.getInferredType().isSubtypeOf(otherType.getInferredType()));

--- a/src/test/java/org/manifold/compiler/TestInferredType.java
+++ b/src/test/java/org/manifold/compiler/TestInferredType.java
@@ -1,6 +1,7 @@
 package org.manifold.compiler;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -45,5 +46,13 @@ public class TestInferredType {
     assertEquals(inferredBitType, v.getType());
     Value withinV = ((InferredValue) v).get();
     assertEquals(BooleanValue.getInstance(false), withinV);
+  }
+
+  @Test
+  public void testSubTypeOfInferredType() {
+    UserDefinedTypeValue bitType = new UserDefinedTypeValue(boolType, "Bit");
+    InferredTypeValue inferredBitType = new InferredTypeValue(bitType);
+
+    assertTrue("inferred is subtype", inferredBitType.isSubtypeOf(bitType));
   }
 }


### PR DESCRIPTION
This is to allow primitive nodes with are defined as `foo = primitive node (in: Bool) -> (Nil)` to be used with `foo(infer)`. Infer is of type `InferredType(Bool)` which was rejected before because it wasn't a subtype of `Bool`.